### PR TITLE
Fix #29: Deploy Documentation on Release

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,9 +4,9 @@
 name: Documentation
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types:
+      - published
 
 jobs:
   Build:


### PR DESCRIPTION
Do not deploy the latest documentation from the main branch but only from actually published releases.